### PR TITLE
feat(core): implement per-request locale support and isolate-safe Lan…

### DIFF
--- a/khadem_template/bin/server.dart
+++ b/khadem_template/bin/server.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:khadem/khadem_dart.dart' show Khadem, ServerCluster;
+import 'package:khadem/khadem_dart.dart' show Khadem, ServerCluster, Lang;
 import '../routes/web.dart';
 import '../bootstrap/app.dart';
 
@@ -23,12 +23,12 @@ Future<void> main(List<String> args) async {
   await ServerCluster(
     port: port ?? Khadem.env.getInt("APP_PORT", defaultValue: 9000),
     globalBootstrap: () async {
-      await Khadem.registerDatabaseServices();
       await lazyBootStrap();
     },
     onInit: (server) async {
       server.serveStatic('public');
       await Khadem.use(container); // sync with main isolate container
+      Lang.use(container.resolve());
       Khadem.registerDatabaseServices();
       registerRoutes(server);
     },

--- a/khadem_template/bootstrap/app.dart
+++ b/khadem_template/bootstrap/app.dart
@@ -20,6 +20,10 @@ Future<void> bootstrap(ContainerInterface container) async {
 
 Future<void> lazyBootStrap() async {
   final config = Khadem.config;
+
+  // 📦 Register the DB services
+  await Khadem.registerDatabaseServices();
+
   // 📦 Register the lazy providers
   Khadem.register(Kernel.lazyProviders);
 

--- a/khadem_template/core/kernel.dart
+++ b/khadem_template/core/kernel.dart
@@ -1,6 +1,10 @@
 import 'package:khadem/khadem_dart.dart'
-    show Middleware, ServiceProvider, MigrationFile, LoggingMiddleware;
-
+    show
+        Middleware,
+        ServiceProvider,
+        MigrationFile,
+        LoggingMiddleware,
+        SetLocaleMiddleware;
 import '../app/Providers/event_service_provider.dart';
 import '../app/Providers/scheduler_service_provider.dart';
 import '../app/http/middleware/cors_middleware.dart';
@@ -27,6 +31,7 @@ class Kernel {
   static List<Middleware> get middlewares => [
         CorsMiddleware(),
         LoggingMiddleware(),
+        SetLocaleMiddleware()
         // Add middleware here
       ];
 

--- a/khadem_template/routes/web.dart
+++ b/khadem_template/routes/web.dart
@@ -11,6 +11,9 @@ void registerRoutes(Server server) {
   // 🏠 Home Routes
   server.group(
       prefix: '/home',
+      middleware: [
+        // Add any middlewares here
+      ],
       routes: (router) async {
         router.get('', HomeController().index);
         router.get('/welcome', HomeController().welcome);

--- a/lib/src/core/http/middleware/middleware_pipeline.dart
+++ b/lib/src/core/http/middleware/middleware_pipeline.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-
 import '../../../contracts/http/middleware_contract.dart';
 import '../../../support/exceptions/middleware_not_found_exception.dart';
 import '../request/request.dart';
@@ -114,7 +113,7 @@ class MiddlewarePipeline {
         .toList();
 
     if (errorHandlers.isEmpty) {
-      return Future.error(error);
+      throw error;
     }
 
     request.params['error'] = error;

--- a/lib/src/core/http/request/request.dart
+++ b/lib/src/core/http/request/request.dart
@@ -14,7 +14,7 @@ class Request {
 
   /// Path parameters extracted from the router.
   Map<String, String> params = {};
-  
+
   String? param(String key) {
     return params[key];
   }
@@ -91,7 +91,7 @@ class Request {
     final validator = Validator(input, rules);
 
     if (!validator.passes()) {
-      return Future.error(ValidationException(validator.errors));
+      throw ValidationException(validator.errors);
     }
 
     return input;

--- a/lib/src/core/http/server/server.dart
+++ b/lib/src/core/http/server/server.dart
@@ -165,8 +165,8 @@ class Server {
 
       Zone.current.fork(
         zoneValues: {
-          RequestContext.zoneKey: RequestContext.run(req, () => null),
-          ResponseContext.zoneKey: ResponseContext.run(res, () => null),
+          RequestContext.zoneKey: req,
+          ResponseContext.zoneKey: res,
           ServerContext.zoneKey: ServerContext(
             request: req,
             response: res,

--- a/lib/src/core/lang/lang.dart
+++ b/lib/src/core/lang/lang.dart
@@ -1,4 +1,5 @@
 import '../../contracts/lang/lang_provider.dart';
+import '../http/context/request_context.dart';
 import 'file_lang_provider.dart';
 
 /// Class used to translate strings with the currently set locale.
@@ -26,11 +27,26 @@ class Lang {
     _provider = provider;
   }
 
+  /// Sets the global locale.
+  ///
+  /// This method changes the locale for all future calls to [t] and [getField].
+  static void setGlobaleLocale(String locale) {
+    _provider.setLocale(locale);
+  }
+
   /// Sets the current request locale.
   ///
   /// This method changes the locale for all future calls to [t] and [getField].
-  static void setRequestLocale(String locale) {
+  static void setRequestLocale(
+    String locale,
+  ) {
     _provider.setLocale(locale);
+
+    RequestContext.set('locale', locale);
+  }
+
+  static String? _getLocale({String? overrideLocale}) {
+    return RequestContext.get<String?>('locale') ?? overrideLocale;
   }
 
   /// Translates a key with optional field and argument.
@@ -45,7 +61,8 @@ class Lang {
   /// locale instead of the current request locale.
   static String t(String key,
       {String field = '', String? arg, String? locale}) {
-    return _provider.t(key, field: field, arg: arg, locale: locale);
+    return _provider.t(key,
+        field: field, arg: arg, locale: _getLocale(overrideLocale: locale));
   }
 
   /// Translates a field label.
@@ -56,6 +73,6 @@ class Lang {
   /// If the [locale] parameter is not null, the method will use the specified
   /// locale instead of the current request locale.
   static String getField(String field, {String? locale}) {
-    return _provider.field(field, locale: locale);
+    return _provider.field(field, locale: _getLocale(overrideLocale: locale));
   }
 }

--- a/lib/src/support/index.dart
+++ b/lib/src/support/index.dart
@@ -14,6 +14,11 @@ export 'exceptions/cache_exceptions.dart';
 export 'middlewares/cache_middleware.dart';
 
 // ========================
+// 📦 Set_locale_middleware.dart
+// ========================
+export 'middlewares/set_locale_middleware.dart';
+
+// ========================
 // 📦 Circular_dependency_exception.dart
 // ========================
 export 'exceptions/circular_dependency_exception.dart';

--- a/lib/src/support/middlewares/set_locale_middleware.dart
+++ b/lib/src/support/middlewares/set_locale_middleware.dart
@@ -1,0 +1,25 @@
+import '../../contracts/http/middleware_contract.dart';
+import '../../core/http/request/request.dart';
+import '../../core/http/response/response.dart';
+import '../../core/lang/lang.dart';
+
+class SetLocaleMiddleware implements Middleware {
+  @override
+  MiddlewareHandler get handler =>
+      (Request req, Response res, NextFunction next) async {
+        try {
+          final lang = req.headers['accept-language']?.first;
+          if (lang == null) return await next();
+          Lang.setRequestLocale(lang);
+          await next();
+        } catch (e) {
+          await next();
+        }
+      };
+
+  @override
+  String get name => 'SetLocale';
+
+  @override
+  MiddlewarePriority get priority => MiddlewarePriority.business;
+}

--- a/lib/src/support/providers/core_service_provider.dart
+++ b/lib/src/support/providers/core_service_provider.dart
@@ -2,6 +2,7 @@ import '../../contracts/config/config_contract.dart';
 import '../../contracts/env/env_interface.dart';
 import '../../contracts/container/container_interface.dart';
 import '../../contracts/events/event_system_interface.dart';
+import '../../contracts/lang/lang_provider.dart';
 import '../../contracts/provider/service_provider.dart';
 import 'package:timezone/data/latest.dart' as tz;
 
@@ -39,6 +40,7 @@ class CoreServiceProvider extends ServiceProvider {
     container.lazySingleton<MiddlewarePipeline>((c) => MiddlewarePipeline());
 
     container.lazySingleton<StorageManager>((c) => StorageManager());
+    container.lazySingleton<LangProvider>((c) => FileLangProvider());
   }
 
   /// Boot logic for core services such as loading `.env` and logging startup.
@@ -58,7 +60,9 @@ class CoreServiceProvider extends ServiceProvider {
     final storageManager = container.resolve<StorageManager>();
     storageManager.fromConfig(config.section('storage') ?? {});
 
-    Lang.setRequestLocale(envSystem.getOrDefault('APP_LOCALE', 'en'));
+    container
+        .resolve<LangProvider>()
+        .setLocale(envSystem.getOrDefault('APP_LOCALE', 'en'));
 
     final logger = container.resolve<Logger>();
     logger.loadFromConfig(config);


### PR DESCRIPTION
This PR introduces enhanced support for request-scoped localization and ensures safe global locale initialization across isolates.

🧩 What's Included
Introduced Lang.setRequestLocale() using RequestContext

Added fallback logic in Lang.t() and Lang.getField() using global locale

Ensured global LangProvider setup per isolate using onInit

Updated CoreServiceProvider to register and initialize LangProvider and fallback locale from .env

Added optional LocaleMiddleware to dynamically set locale based on Accept-Language header

🧪 How to Test
Run the app and send requests with different Accept-Language headers.

Ensure the correct language is used per request.

Verify fallback to APP_LOCALE when header is not set.

📌 Notes
This approach ensures isolation-safe localization behavior

Can be extended in future for tenant-specific or per-user localization


